### PR TITLE
Check members strikes and add moderation category

### DIFF
--- a/libraries/strikes/StrikeUser.js
+++ b/libraries/strikes/StrikeUser.js
@@ -1,13 +1,12 @@
 import fs from "fs";
 import Strike from "./Strike.js";
 
-/**
- * @type {number} The delta between each strike expire
- */
-const STRIKE_EXPIRE_DELTA = 90 * 24 * 60 * 60 * 1000;
-
 class StrikeUser {
     #strikes;
+    /**
+     * @type {number} The delta between each strike expire
+     */
+    static STRIKE_EXPIRE_DELTA = 90 * 24 * 60 * 60 * 1000;
 
     constructor(userid, userdata) {
         this.userid = userid;
@@ -58,7 +57,7 @@ class StrikeUser {
             let currentStrikeTimestamp = strike.createdAt;
             let nextStrikeTimestamp = nextStrike ? nextStrike.createdAt : Date.now();
 
-            let newStrikesForgiven = strikesForgiven + Math.floor((nextStrikeTimestamp - currentStrikeTimestamp) / STRIKE_EXPIRE_DELTA)
+            let newStrikesForgiven = strikesForgiven + Math.floor((nextStrikeTimestamp - currentStrikeTimestamp) / StrikeUser.STRIKE_EXPIRE_DELTA)
 
             // You can't forgive more strikes then you already have
             // To prevent this from happening we only allow i + 1 (the current amount of strikes) to be forgiven

--- a/modules/commands/general/help.js
+++ b/modules/commands/general/help.js
@@ -7,6 +7,7 @@ export default {
     async execute(interaction){
         let description = [
             `:speech_balloon: General`,
+            `:tools: Moderation`,
             `:exclamation: All commands`
         ];
         let help = new EmbedBuilder();
@@ -22,6 +23,10 @@ export default {
     					label: "General",
 					    value: 'general_help',
 				    },
+                    {
+                        label: "Moderation",
+                        value: 'moderation_help',
+                    },
                     {
     					label: "All commands",
 					    value: 'all_commands_help',

--- a/modules/commands/moderation/strike.js
+++ b/modules/commands/moderation/strike.js
@@ -59,7 +59,7 @@ async function createTempStrikeChannel(user, strike, strikeUser){
 
 export default {
     "name": "strike",
-    "category": "general",
+    "category": "moderation",
     "description": "Give a member a strike",
     "options": [
         {

--- a/modules/commands/moderation/strikes.js
+++ b/modules/commands/moderation/strikes.js
@@ -1,0 +1,61 @@
+import StrikeUser from "../../../libraries/strikes/StrikeUser.js";
+import {EmbedBuilder} from "discord.js";
+import RoleChecker from "../../../libraries/permissions/RoleChecker.js";
+
+export default {
+    "name": "strikes",
+    "category": "moderation",
+    "description": "Check the amount of strikes you have",
+    "options": [
+        {
+            name: "user",
+            description: "The user you want check (staff only)",
+            type: "USER",
+            required: false
+        }
+    ],
+    async execute(interaction){
+        const isTrialOrAbove = RoleChecker.isTrialOrAbove(interaction.member);
+
+        const user = (
+            interaction.options.getUser("user") &&
+            isTrialOrAbove
+        ) ? interaction.options.getUser("user") :
+            interaction.member.user;
+
+        let strikeUser = StrikeUser.getUser(user.id);
+        let strikes = isTrialOrAbove ? strikeUser.getActiveStrikes() : strikeUser.getActiveStrikes().filter(strike => strike.active);
+
+        let strikeCount = strikeUser.getStrikeCount();
+        let activeStrikeCount = strikeUser.getActiveStrikeCount();
+
+        let strikeMessage = `Strikes ever received: ${strikeCount}\nCurrently active strikes: ${activeStrikeCount}\n`;
+
+        if(activeStrikeCount > 0) {
+            let timestampNextExpiry = Date.now() + (StrikeUser.STRIKE_EXPIRE_DELTA - ((Date.now() - strikes[strikes.length - 1].createdAt) % StrikeUser.STRIKE_EXPIRE_DELTA));
+            strikeMessage += `Next strike expires at: <t:${Math.floor(timestampNextExpiry / 1000)}>\n`;
+        }
+
+        if(isTrialOrAbove) {
+            strikeMessage += `All strikes:\n`;
+        }else{
+            strikeMessage += `Currently active strikes:\n`;
+        }
+
+        for(let i = 0; i < strikes.length; i++) {
+            let strike = strikes[i];
+            strikeMessage += `${i + 1}. ${strike.reason} <t:${Math.floor(strike.createdAt / 1000)}>`;
+            if(isTrialOrAbove) {
+                strikeMessage += ` (Active: ${strike.active})`;
+            }
+            strikeMessage += `\n`;
+        }
+
+        let strikesEmbed = new EmbedBuilder();
+        strikesEmbed.setTitle('Your strikes');
+        strikesEmbed.setDescription(strikeMessage);
+        strikesEmbed.setColor(0x00FFFF);
+
+        interaction.reply({embeds: [strikesEmbed], ephemeral: true});
+    }
+};


### PR DESCRIPTION
Closes #10 
Closes #19 

There are some differences between what a mod and a member can see in their strikes list.
Moderators can see all information but regular members can only see their currently active strikes.